### PR TITLE
Namespace and variable reference tidying

### DIFF
--- a/R/chords_bigram.R
+++ b/R/chords_bigram.R
@@ -19,8 +19,6 @@
 chords_ngram <- function(data, n = 2){
   if(!is.null(data)){
     chords_ngram <- data %>% 
-      dplyr::mutate(date = 
-                      forcats::fct_explicit_na(date)) %>% 
       dplyr::mutate(
         chords_ngram = zoo::rollapply(.data[["chord"]], n, paste0, 
                                       collapse = " ", 

--- a/R/chords_bigram.R
+++ b/R/chords_bigram.R
@@ -22,7 +22,7 @@ chords_ngram <- function(data, n = 2){
       dplyr::mutate(date = 
                       forcats::fct_explicit_na(date)) %>% 
       dplyr::mutate(
-        chords_ngram = zoo::rollapply(chord, n, paste0, 
+        chords_ngram = zoo::rollapply(.data[["chord"]], n, paste0, 
                                       collapse = " ", 
                                       align = 'right', 
                                       partial = TRUE, 

--- a/R/clean.R
+++ b/R/clean.R
@@ -21,7 +21,7 @@ clean <- function(da, column = "chord", long = 15, message = TRUE){
   if(column %in% names(da)){
     filt <- da %>% 
       dplyr::mutate(long_str = stringr::str_length(!!column)) %>% 
-      dplyr::filter(long_str <= long)
+      dplyr::filter(.data[["long_str"]] <= long)
   
     rem <- dim(da)[1] - dim(filt)[1]
     if(message){

--- a/R/feature_extraction.R
+++ b/R/feature_extraction.R
@@ -6,7 +6,7 @@
 #' from.
 #'
 #' @return A dataframe with the chords set add with  
-#' logical features, to indicate if each chord is: 
+#' logical features (1 or 0), to indicate if each chord is: 
 # - minor 
 # - diminished
 # - augmented
@@ -21,43 +21,19 @@
 # - chords with varying bass 
 #' @examples{
 #' \donttest{
-#'   songs <- chorrrds::get_songs("tim-maia")
+#'   songs <- get_songs("tim-maia")
 #'   chords <- get_chords(songs$url[4])
 #'   feature_extraction(chords)
 #'}
 #'}
 #' @export
-
 feature_extraction <- function(data){
-  if(!is.null(data)){
-    data_feat <- data %>% 
-      dplyr::mutate(
-        # minor chords
-        minor = stringr::str_detect(chord, "m") * 1,
-        # diminished
-        dimi = stringr::str_detect(chord, "dim|\u00b0") * 1,
-        # augmented
-        augm = stringr::str_detect(chord, "aug|\\+") * 1,
-        # sus 
-        sus = stringr::str_detect(chord, "(sus)") * 1,
-        # chords with the 7th
-        seventh = stringr::str_detect(chord, "7") * 1,
-        # chords with the major 7th
-        seventh_M = stringr::str_detect(chord, "7(M|\\+)" ) * 1,
-        # chords with the 6th
-        sixth = stringr::str_detect(chord, "(6|13)") * 1,
-        # chords with the 4th
-        fourth = stringr::str_detect(chord, "(4|11)") * 1,
-        # chords with the augmented 5th
-        fifth_aug = stringr::str_detect(chord, "5(#|\\+)") * 1,
-        # chords with the diminished 5th
-        fifth_dim = stringr::str_detect(chord, "5(b|-)") * 1,
-        # chords with the 9th
-        ninth = stringr::str_detect(chord, "(9|2)") * 1,
-        # chords with varying bass
-        bass = stringr::str_detect(chord, 
-                                   pattern = "(?<=/).*")*1
-      )
-    return(data_feat)
-  }
+  id <- c("minor", "dimi", "augm", "sus", "seventh", "seventh_M", "sixth", 
+          "fourth", "fifth_aug", "fifth_dim", "ninth", "bass")
+  pat <- c("m", "dim|\u00b0", "aug|\\+", "sus", "7", "7(M|\\+)", "(6|13)", 
+           "(4|11)", "5(#|\\+)", "5(b|-)", "(9|2)", "/[A-G]")
+  feat <- lapply(pat, function(x) as.integer(grepl(x, data$chord))) %>% 
+    stats::setNames(id) %>%
+    as.data.frame(stringsAsFactors = FALSE)
+  dplyr::bind_cols(data, feat)
 }

--- a/R/get_chords.R
+++ b/R/get_chords.R
@@ -51,7 +51,7 @@ get_chords <- function(song_url, nf = FALSE){
     dplyr::mutate(
       artist = sapply(parsed_names, "[", 1),
       song = sapply(parsed_names, "[", 2)) %>% 
-    dplyr::mutate_at(vars(artist, song), list(~stringr::str_to_title(.)))
+    dplyr::mutate_at(c("artist", "song"), list(~stringr::str_to_title(.)))
       
   return(df)
   

--- a/R/search_data.R
+++ b/R/search_data.R
@@ -17,7 +17,7 @@
 #'
 
 search_data <- function(name){
-  av_data <- data(package = "chorrrds")$results[ ,3]
+  av_data <- utils::data(package = "chorrrds")$results[ ,3]
 
   for(i in 1:length(av_data)){
     cond <- grepl(name, av_data[i])

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,5 +29,5 @@ NULL
 not_in <- function(x,y)!('%in%'(x,y))
 
 # Get rid of NOTES
-globalVariables(c(".", ".data", "date"))
+globalVariables(c(".", ".data"))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,6 +29,5 @@ NULL
 not_in <- function(x,y)!('%in%'(x,y))
 
 # Get rid of NOTES
-globalVariables(c(".", ".data", "name", "data", "long_str", "chord", 
-                  "chord_bigram"))
+globalVariables(c(".", ".data", "date"))
 

--- a/man/feature_extraction.Rd
+++ b/man/feature_extraction.Rd
@@ -12,7 +12,7 @@ from.}
 }
 \value{
 A dataframe with the chords set add with  
-logical features, to indicate if each chord is:
+logical features (1 or 0), to indicate if each chord is:
 }
 \description{
 Extracts features from a chords dataset.
@@ -20,7 +20,7 @@ Extracts features from a chords dataset.
 \examples{
 {
 \donttest{
-  songs <- chorrrds::get_songs("tim-maia")
+  songs <- get_songs("tim-maia")
   chords <- get_chords(songs$url[4])
   feature_extraction(chords)
 }


### PR DESCRIPTION
Using explicit namespaces and the `.data[[` dataframe variable lookups is good use in packages. Fewer issues on package checking and you don't have to populate the `globalVariables` list with special named variables.

I see a remaining issue in `chords_ngram` but I left it alone because I didn't understand the function. There seems to be reference to a `date` column that doesn't exist. I couldn't understand how to fix it but this function does not run. For this reason I retained the "date" in `globalVariables`. If I could understand this function I could write some unit tests for it.